### PR TITLE
Negative time bug fix

### DIFF
--- a/src/contexts/GameContextProvider.tsx
+++ b/src/contexts/GameContextProvider.tsx
@@ -659,7 +659,7 @@ export const GameContextProvider = ({ children }: props) => {
     if (timerStarted && !gameOverFlag && startTimestamp) {
       intervalId = setInterval(() => {
         setRemainingTime((prevTime) => {
-          if (prevTime === 0 && intervalId) {
+          if (prevTime <= 0 && intervalId) {
             // if (intervalId && true) {
             clearInterval(intervalId);
             setStartTimestamp(null);


### PR DESCRIPTION
Bug description: When you start a game in a mobile, you block the phone and wait for the game time to end and after that you unblock the phone and go back to the game you'll see the timer in negative numbers and you cannot lost by time.